### PR TITLE
Use --appimage-extract rather than unappimage

### DIFF
--- a/de.hoppfoundation.klassenzimmer.yaml
+++ b/de.hoppfoundation.klassenzimmer.yaml
@@ -23,19 +23,20 @@ finish-args:
     # Also used for inhibit
   - --talk-name=org.freedesktop.login1
 modules:
-  - name: unappimage
-    buildsystem: simple
-    build-commands:
-      - make -C squashfs-tools -j ${FLATPAK_BUILDER_N_JOBS} install INSTALL_DIR=/app/bin
-    sources:
-      - type: git
-        url: https://github.com/refi64/unappimage
-        commit: d7f86f2a0d7ec3a69211125207d5f127386b849a
-
+#   - name: unappimage
+#     buildsystem: simple
+#     build-commands:
+#       - make -C squashfs-tools -j ${FLATPAK_BUILDER_N_JOBS} install INSTALL_DIR=/app/bin
+#     sources:
+#       - type: git
+#         url: https://github.com/refi64/unappimage
+#         commit: d7f86f2a0d7ec3a69211125207d5f127386b849a
+# Removed, since launching the appimage with the --appimage-extract option works just fine, and also probably helps to decrease server load -Oro
   - name: digitales-klassenzimmer
     buildsystem: simple
     build-commands:
-      - unappimage digitales-klassenzimmer-x86_64.AppImage
+      - chmod +x digitales-klassenzimmer-x86_64.AppImage
+      - ./digitales-klassenzimmer-x86_64.AppImage --appimage-extract
       - rm digitales-klassenzimmer-x86_64.AppImage
 
       - cp squashfs-root/digitales-klassenzimmer.desktop de.hoppfoundation.klassenzimmer.desktop

--- a/de.hoppfoundation.klassenzimmer.yaml
+++ b/de.hoppfoundation.klassenzimmer.yaml
@@ -23,15 +23,6 @@ finish-args:
     # Also used for inhibit
   - --talk-name=org.freedesktop.login1
 modules:
-#   - name: unappimage
-#     buildsystem: simple
-#     build-commands:
-#       - make -C squashfs-tools -j ${FLATPAK_BUILDER_N_JOBS} install INSTALL_DIR=/app/bin
-#     sources:
-#       - type: git
-#         url: https://github.com/refi64/unappimage
-#         commit: d7f86f2a0d7ec3a69211125207d5f127386b849a
-# Removed, since launching the appimage with the --appimage-extract option works just fine, and also probably helps to decrease server load -Oro
   - name: digitales-klassenzimmer
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
Removed, since launching the appimage with the --appimage-extract option works just fine, and also probably helps to decrease server load 